### PR TITLE
[fix] Delete deprecated link to the "lv_app" submodule from the .gitm…

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,4 @@
 	url = https://github.com/littlevgl/lv_examples.git
 [submodule "lv_drivers"]
 	path = lv_drivers
-	url = https://github.com/littlevgl/lv_drivers.git
-[submodule "lv_apps"]
-	path = lv_apps
-	url = https://github.com/littlevgl/lv_apps.git
+	url = https://github.com/littlevgl/lv_drivers.git 


### PR DESCRIPTION
Based on #71 . Delete deprecated link to the "lv_app" submodule from the .gitmodules file. The pointer to the submodule repository is not set and it cause error during recursive submodule update command.