### PR TITLE
Add note for running Xquartz on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ and run a command similar to:
 docker run -e DISPLAY=10.103.56.101:0 lvgl_simulator
 ```
 
+Note that on macOS, you may need to enable indirect GLX rendering before starting Xquartz:
+```
+defaults write org.macosforge.xquartz.X11 enable_iglx -bool true
+open -a Xquartz
+```
+
 For Linux environments with X Server, the following will the `docker run` command. Note that the first command, `xhost +` grants access to X server to everyone.
 
 ```


### PR DESCRIPTION
I was having difficulty running the docker command on macOS while following the linked blog post, and seeing this error:

```
> docker run -e DISPLAY=192.168.1.11:0 lvgl_simulator
X Error of failed request:  GLXBadContext
  Major opcode of failed request:  149 (GLX)
  Minor opcode of failed request:  6 (X_GLXIsDirect)
  Serial number of failed request:  88
  Current serial number in output stream:  87
```

I was able to fix the issue by enabling indirect rendering and restarting Xquartz:
`defaults write org.macosforge.xquartz.X11 enable_iglx -bool true`

macOS 10.15.4
Xquartz 2.7.11

Tip came from this post:
https://www.visitusers.org/index.php?title=Re-enabling_INdirect_glx_on_your_X_server