### PR TITLE
Simplify Dockerfile + support forked images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,17 +19,9 @@ RUN apt update && apt install -y \
     libgl1-mesa-glx \
     x11-apps
 
-ENV DISPLAY=:0 \
-    LV_SIM_BRANCH=master \
-    LV_SIM_REPO=lv_sim_eclipse_sdl \
-    LV_USER=lvgl
+ENV DISPLAY=:0
 
-# Prevents Docker from caching
-ADD https://api.github.com/repos/$LV_USER/$LV_SIM_REPO/git/refs/heads/$LV_BRANCH version.json
-
-RUN git clone --recursive -b$LV_SIM_BRANCH https://github.com/$LV_USER/$LV_SIM_REPO.git
-
-WORKDIR /$LV_SIM_REPO
+ADD . .
 
 RUN make -j3
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apt update && apt install -y \
 
 ENV DISPLAY=:0
 
-ADD . .
+COPY . .
 
 RUN make -j3
 


### PR DESCRIPTION
The Dockerfile is more complicated than it needs to be, and can be simplified with improved functionality.

Presently it git clones the master branch of https://github.com/lvgl/lv_sim_eclipse_sdl This means any local changes to the repo or submodule are ignored when building the Dockerfile, making testing of local changes more difficult.

Instead, we can simply `COPY` the local working directory to the docker image. Any local changes in this repo or submodules will be reflected in the build from `docker build -t lvgl_simulator .`

We also speed up docker image building by skipping the git clone step. I've verified the new docker image still runs:
<img width="508" alt="Screen Shot 2020-12-01 at 3 03 07 PM" src="https://user-images.githubusercontent.com/220799/100807324-f6bce000-33e6-11eb-8ef5-987b9a476729.png">
