### PR TITLE
Investigated and fixed build with CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ demo
 .pydevproject
 /.metadata/
 /.tracecompass
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ demo
 /.metadata/
 /.tracecompass
 build/
+lvgl_lib_cmake/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ option(USE_CONAN OFF)
 
 set (SDL_TARGET_NAME "")
 if( USE_CONAN )
+    set( CONAN_DISABLE_CHECK_COMPILER TRUE )
     include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
     conan_basic_setup(TARGETS)
     set(SDL_TARGET_NAME CONAN_PKG::sdl2)
@@ -34,7 +35,7 @@ target_link_libraries(lv_examples PUBLIC lvgl_conf lvgl lv_drivers)
 
 add_executable(lvgl_sim_eclipse main.c mouse_cursor_icon.c)
 
-#add_subdirectory (lv_lib_rlottie)
+add_subdirectory (lv_lib_rlottie)
 
 target_include_directories(
     lvgl_sim_eclipse
@@ -48,4 +49,4 @@ target_compile_features(
     cxx_std_17
 )
 
-target_link_libraries(lvgl_sim_eclipse PRIVATE lvgl lv_examples lv_lib_rlotti)
+target_link_libraries(lvgl_sim_eclipse PRIVATE lvgl lv_examples lv_lib_rlottie)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,14 +2,19 @@ cmake_minimum_required(VERSION 3.14)
 
 project(lvgl_simulator C CXX ASM)
 
-option(USE_CONAN_PACKAGE_MANAGER OFF)
+option(USE_CONAN OFF)
 
-if( USE_CONAN_PACKAGE_MANAGER )
+set (SDL_TARGET_NAME "")
+if( USE_CONAN )
     include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
     conan_basic_setup(TARGETS)
+    set(SDL_TARGET_NAME CONAN_PKG::sdl2)
 else()
     find_package(SDL2 REQUIRED SDL2)
+    set(SDL_TARGET_NAME SDL2)
 endif()
+
+message("[Pacakges]SDL target name is: ${SDL_TARGET_NAME}")
 
 include(cmake/declare_lvgl_target_library.cmake)
 
@@ -19,8 +24,13 @@ target_include_directories(lvgl_conf INTERFACE )
 set (GENERATED_LVGL_PATHS_DIR ${CMAKE_CURRENT_LIST_DIR}/lvgl_lib_cmake)
 
 lvgl_create_static_library_target(lvgl ${GENERATED_LVGL_PATHS_DIR} lvgl_conf)
-lvgl_create_static_library_target(lv_examples ${GENERATED_LVGL_PATHS_DIR} lvgl lvgl_conf)
-lvgl_create_static_library_target(lv_drivers ${GENERATED_LVGL_PATHS_DIR} lvgl lvgl_conf)
+lvgl_create_static_library_target(lv_drivers ${GENERATED_LVGL_PATHS_DIR})
+lvgl_create_static_library_target(lv_examples ${GENERATED_LVGL_PATHS_DIR})
+
+target_link_libraries(lvgl PUBLIC lvgl_conf)
+target_link_libraries(lv_drivers PUBLIC lvgl_conf lvgl ${SDL_TARGET_NAME})
+target_link_libraries(lv_examples PUBLIC lvgl_conf lvgl lv_drivers)
+
 
 add_executable(lvgl_sim_eclipse main.c mouse_cursor_icon.c)
 
@@ -38,4 +48,4 @@ target_compile_features(
     cxx_std_17
 )
 
-target_link_libraries(lvgl_sim_eclipse PRIVATE lvgl lv_lib_rlottie SDL2 )
+target_link_libraries(lvgl_sim_eclipse PRIVATE lvgl lv_examples lv_lib_rlotti)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,25 +11,31 @@ else()
     find_package(SDL2 REQUIRED SDL2)
 endif()
 
-set (APP_TARGET lvgl_simulator)
+include(cmake/declare_lvgl_target_library.cmake)
 
-# file(GLOB_RECURSE INCLUDES " lvgl/*.h lv_drivers/*.h" "lv_examples/*.h"    "lv_lib_rlottie/*.h" "./*.h" )
-# file(GLOB_RECURSE SOURCES  " lvgl/*.c lv_drivers/*.c" "lv_examples/*.c"   "lv_lib_rlottie/.*c")
+add_library(lvgl_conf INTERFACE)
+target_include_directories(lvgl_conf INTERFACE )
 
-add_executable(${APP_TARGET} ${SOURCES} ${INCLUDES})
+set (GENERATED_LVGL_PATHS_DIR ${CMAKE_CURRENT_LIST_DIR}/lvgl_lib_cmake)
+
+lvgl_create_static_library_target(lvgl ${GENERATED_LVGL_PATHS_DIR} lvgl_conf)
+lvgl_create_static_library_target(lv_examples ${GENERATED_LVGL_PATHS_DIR} lvgl lvgl_conf)
+lvgl_create_static_library_target(lv_drivers ${GENERATED_LVGL_PATHS_DIR} lvgl lvgl_conf)
+
+add_executable(lvgl_sim_eclipse main.c mouse_cursor_icon.c)
 
 #add_subdirectory (lv_lib_rlottie)
 
 target_include_directories(
-    ${APP_TARGET}
+    lvgl_sim_eclipse
     PRIVATE
     ${CMAKE_CURRRENT_LIST_DIR}
 )
 
 target_compile_features(
-    ${APP_TARGET}
+    lvgl_sim_eclipse
     PRIVATE
     cxx_std_17
 )
 
-target_link_libraries(${APP_TARGET} PRIVATE lv_lib_rlottie SDL2 )
+target_link_libraries(lvgl_sim_eclipse PRIVATE lvgl lv_lib_rlottie SDL2 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.14)
 project(lvgl_simulator C CXX ASM)
 
 option(USE_CONAN OFF)
+option(USE_TARGET_BASED_BUILD OFF)
 
 set (SDL_TARGET_NAME "")
 if( USE_CONAN )
@@ -15,7 +16,12 @@ else()
     set(SDL_TARGET_NAME SDL2)
 endif()
 
-message("[Pacakges]SDL target name is: ${SDL_TARGET_NAME}")
+message("[Pacakges] SDL target name is: ${SDL_TARGET_NAME}")
+message("[Build]    Target based build is ${USE_TARGET_BASED_BUILD}")
+
+add_subdirectory (lv_lib_rlottie)
+
+if ( USE_TARGET_BASED_BUILD )
 
 include(cmake/declare_lvgl_target_library.cmake)
 
@@ -32,10 +38,7 @@ target_link_libraries(lvgl PUBLIC lvgl_conf)
 target_link_libraries(lv_drivers PUBLIC lvgl_conf lvgl ${SDL_TARGET_NAME})
 target_link_libraries(lv_examples PUBLIC lvgl_conf lvgl lv_drivers)
 
-
 add_executable(lvgl_sim_eclipse main.c mouse_cursor_icon.c)
-
-add_subdirectory (lv_lib_rlottie)
 
 target_include_directories(
     lvgl_sim_eclipse
@@ -43,10 +46,32 @@ target_include_directories(
     ${CMAKE_CURRRENT_LIST_DIR}
 )
 
+target_link_libraries(lvgl_sim_eclipse PRIVATE lvgl lv_examples lv_lib_rlottie)
+
+else()
+
+set(LOTTIE_MODULE OFF)
+set(LOTTIE_THREAD OFF)
+set(BUILD_SHARED_LIBS OFF)
+
+include_directories(
+    ${CMAKE_CURRENT_LIST_DIR}
+    ${CMAKE_CURRENT_LIST_DIR}/lvgl
+    ${CMAKE_CURRENT_LIST_DIR}/lv_examples
+    ${CMAKE_CURRENT_LIST_DIR}/lv_drivers
+    ${CMAKE_CURRENT_LIST_DIR}/lv_lib_rlottie
+    ${CMAKE_CURRENT_LIST_DIR}/lv_lib_rlottie/rlottie_lib/rlottie/inc
+)
+
+file(GLOB_RECURSE SOURCES CONFIGURE_DEPENDS lvgl/src/*.c lv_drivers/*.c lv_examples/*.c lv_lib_rlottie/*.c )
+
+add_executable(lvgl_sim_eclipse main.c mouse_cursor_icon.c ${SOURCES})
+target_link_libraries(lvgl_sim_eclipse PRIVATE ${SDL_TARGET_NAME} rlottie)
+
+endif()
+
 target_compile_features(
     lvgl_sim_eclipse
     PRIVATE
-    cxx_std_17
+    cxx_std_14
 )
-
-target_link_libraries(lvgl_sim_eclipse PRIVATE lvgl lv_examples lv_lib_rlottie)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,20 +1,35 @@
-cmake_minimum_required(VERSION 3.10)
-project(lvgl)
-set(CMAKE_C_STANDARD 11)#C11
-set(CMAKE_CXX_STANDARD 17)#C17
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+cmake_minimum_required(VERSION 3.14)
 
-INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR})
+project(lvgl_simulator C CXX ASM)
 
-file(GLOB_RECURSE INCLUDES "lv_drivers/*.h" "lv_examples/*.h"  "lvgl/*.h"  "lv_lib_rolitte/*.h" "./*.h" )
-file(GLOB_RECURSE SOURCES  "lv_drivers/*.c" "lv_examples/*.c"  "lvgl/*.c" "lv_lib_rolettie/.*c")
+option(USE_CONAN_PACKAGE_MANAGER OFF)
 
-add_subdirectory (lv_lib_rlottie)
+if( USE_CONAN_PACKAGE_MANAGER )
+    include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+    conan_basic_setup(TARGETS)
+else()
+    find_package(SDL2 REQUIRED SDL2)
+endif()
 
-SET(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin) 
+set (APP_TARGET lvgl_simulator)
 
-find_package(SDL2 REQUIRED SDL2)
-include_directories(${SDL2_INCLUDE_DIRS})
-add_executable(main main.c mouse_cursor_icon.c ${SOURCES} ${INCLUDES})
-target_link_libraries(main PRIVATE SDL2 )
-add_custom_target (run COMMAND ${EXECUTABLE_OUTPUT_PATH}/main)
+# file(GLOB_RECURSE INCLUDES " lvgl/*.h lv_drivers/*.h" "lv_examples/*.h"    "lv_lib_rlottie/*.h" "./*.h" )
+# file(GLOB_RECURSE SOURCES  " lvgl/*.c lv_drivers/*.c" "lv_examples/*.c"   "lv_lib_rlottie/.*c")
+
+add_executable(${APP_TARGET} ${SOURCES} ${INCLUDES})
+
+#add_subdirectory (lv_lib_rlottie)
+
+target_include_directories(
+    ${APP_TARGET}
+    PRIVATE
+    ${CMAKE_CURRRENT_LIST_DIR}
+)
+
+target_compile_features(
+    ${APP_TARGET}
+    PRIVATE
+    cxx_std_17
+)
+
+target_link_libraries(${APP_TARGET} PRIVATE lv_lib_rlottie SDL2 )

--- a/cmake/declare_lvgl_target_library.cmake
+++ b/cmake/declare_lvgl_target_library.cmake
@@ -1,0 +1,35 @@
+function (lvgl_create_static_library_target TARGET_NAME GENERATED_FILES_DIR TARGET_LINK_EXT_LIBRARIES )
+
+    set(LV_TARGET_SOURCES_PATH "${GENERATED_FILES_DIR}/${TARGET_NAME}_c.txt")
+    set (LV_TARGET_HEADERS_PATH "${GENERATED_FILES_DIR}/${TARGET_NAME}_h.txt")
+
+    file(STRINGS ${LV_TARGET_SOURCES_PATH} C_LVGL_SOURCES )
+    file(STRINGS ${LV_TARGET_HEADERS_PATH} C_LVGL_HEADERS )
+
+    message("Current target is ${TARGET_NAME}")
+    message("${TARGET_NAME} source path is ${LV_TARGET_SOURCES_PATH}")
+    message("${TARGET_NAME} includes path is ${LV_TARGET_HEADERS_PATH}")
+
+    set (MODIFIED_SOURCE_LIST "")
+    foreach(SOURCE_PATH ${C_LVGL_SOURCES} )
+        string(REPLACE "./" "${TARGET_NAME}/" SOURCE_OUT ${SOURCE_PATH})
+        list(APPEND MODIFIED_SOURCE_LIST ${SOURCE_OUT})
+    endforeach()
+    
+    set (MODIFIED_INCLUDES_LIST "")
+    foreach(INCLUDE_PATH ${C_LVGL_HEADERS} )
+        string(REPLACE "./" "${TARGET_NAME}/" INCLUDE_OUT ${INCLUDE_PATH})
+        list(APPEND MODIFIED_INCLUDES_LIST ${INCLUDE_OUT})
+    endforeach()
+
+    set_source_files_properties(${MODIFIED_SOURCE_LIST} PROPERTIES LANGUAGE C)
+    add_library( ${TARGET_NAME} STATIC ${MODIFIED_SOURCE_LIST})
+
+    target_sources(${TARGET_NAME} PUBLIC ${MODIFIED_INCLUDES_LIST} ${MODIFIED_SOURCE_LIST})
+    if(WIN32)
+        target_compile_definitions(${TARGET_NAME} PRIVATE _CRT_SECURE_NO_WARNINGS)
+    endif(WIN32)
+
+    
+    target_link_libraries( ${TARGET_NAME} PUBLIC ${TARGET_LINK_EXT_LIBRARIES})
+endfunction()

--- a/cmake/declare_lvgl_target_library.cmake
+++ b/cmake/declare_lvgl_target_library.cmake
@@ -1,4 +1,4 @@
-function (lvgl_create_static_library_target TARGET_NAME GENERATED_FILES_DIR TARGET_LINK_EXT_LIBRARIES )
+function (lvgl_create_static_library_target TARGET_NAME GENERATED_FILES_DIR)
 
     set(LV_TARGET_SOURCES_PATH "${GENERATED_FILES_DIR}/${TARGET_NAME}_c.txt")
     set (LV_TARGET_HEADERS_PATH "${GENERATED_FILES_DIR}/${TARGET_NAME}_h.txt")
@@ -19,17 +19,17 @@ function (lvgl_create_static_library_target TARGET_NAME GENERATED_FILES_DIR TARG
     set (MODIFIED_INCLUDES_LIST "")
     foreach(INCLUDE_PATH ${C_LVGL_HEADERS} )
         string(REPLACE "./" "${TARGET_NAME}/" INCLUDE_OUT ${INCLUDE_PATH})
-        list(APPEND MODIFIED_INCLUDES_LIST ${INCLUDE_OUT})
+        get_filename_component(LV_INCLUDE_DIR ${INCLUDE_PATH} DIRECTORY)
+        list(APPEND MODIFIED_INCLUDES_LIST ${LV_INCLUDE_DIR})
     endforeach()
 
     set_source_files_properties(${MODIFIED_SOURCE_LIST} PROPERTIES LANGUAGE C)
     add_library( ${TARGET_NAME} STATIC ${MODIFIED_SOURCE_LIST})
-
-    target_sources(${TARGET_NAME} PUBLIC ${MODIFIED_INCLUDES_LIST} ${MODIFIED_SOURCE_LIST})
     if(WIN32)
-        target_compile_definitions(${TARGET_NAME} PRIVATE _CRT_SECURE_NO_WARNINGS)
+        target_compile_definitions(${TARGET_NAME} PUBLIC _CRT_SECURE_NO_WARNINGS)
     endif(WIN32)
 
-    
-    target_link_libraries( ${TARGET_NAME} PUBLIC ${TARGET_LINK_EXT_LIBRARIES})
+    list(REMOVE_DUPLICATES MODIFIED_INCLUDES_LIST)
+    list(APPEND MODIFIED_INCLUDES_LIST "${TARGET_NAME}")
+    target_include_directories(${TARGET_NAME} PUBLIC ${MODIFIED_INCLUDES_LIST} )
 endfunction()

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,0 +1,12 @@
+[requires]
+sdl2/2.0.10@bincrafters/stable
+
+[options]
+sdl2_image:tif=False
+sdl2:shared=True
+
+[imports]
+bin, *.dll -> bin
+
+[generators]
+cmake

--- a/generate_cmake_filelist_targets.sh
+++ b/generate_cmake_filelist_targets.sh
@@ -1,0 +1,10 @@
+mkdir lvgl_lib_cmake
+cd lv_drivers
+find . -name "*.c" > ../lvgl_lib_cmake/lv_drivers_c.txt
+find . -name "*.h" > ../lvgl_lib_cmake/lv_drivers_h.txt
+cd ../lv_examples
+find . -name "*.c" > ../lvgl_lib_cmake/lv_examples_c.txt
+find . -name "*.h" > ../lvgl_lib_cmake/lv_examples_h.txt
+cd ../lvgl
+find . -name "*.c" > ../lvgl_lib_cmake/lvgl_c.txt
+find . -name "*.h" > ../lvgl_lib_cmake/lvgl_h.txt

--- a/main.c
+++ b/main.c
@@ -7,9 +7,8 @@
 /*********************
  *      INCLUDES
  *********************/
-#define _DEFAULT_SOURCE /* needed for usleep() */
 #include <stdlib.h>
-#include <unistd.h>
+#include <stdio.h>
 #define SDL_MAIN_HANDLED /*To fix SDL's "undefined reference to WinMain" \
                             issue*/
 #include <SDL2/SDL.h>
@@ -83,7 +82,7 @@ int main(int argc, char **argv)
     /* Periodically call the lv_task handler.
      * It could be done in a timer interrupt or an OS task too.*/
     lv_task_handler();
-    usleep(5 * 1000);
+    SDL_Delay(5);
   }
 
   return 0;


### PR DESCRIPTION
### Tasks
- Refactored CMakeLists and fixed build.
- Added support of generating LVGL targets from current project sctructure.
- Added support of Conan package manager for SDL dependency
- Instead of using <unistd.h> the corresponding function from SDL library is used.

### Build steps:
`git submodule update --init --recursive
sh generate_cmake_filelist_targets.sh
mkdir build
cd build
`
In case of using Conan for SDL2 dependency:
`conan install ..`

For windows build with conan:
` cmake -G"Visual Studio 16 2019" -Ax64 .. -DUSE_CONAN=ON
cmake --build .
`
For windows build without conan:
` cmake -G"Visual Studio 16 2019" -Ax64 ..
cmake --build .
`
Built binaries are available in build/bin directory.
