### PR TITLE
Add libpng-dev to Linux packages to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can download SDL from https://www.libsdl.org/
 
 On on Linux you can install it via terminal:
 ```
-sudo apt-get update && sudo apt-get install -y build-essential libsdl2-dev
+sudo apt-get update && sudo apt-get install -y build-essential libsdl2-dev libpng-dev
 ```
 
 ### Install Eclipse CDT


### PR DESCRIPTION
The problem was reported here: https://forum.lvgl.io/t/pc-simulator-linux-eclipse-error-cannot-find-lpng/6768